### PR TITLE
Allow 'Undo' action for deleting active and bookmarked CHats

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_6_API_33.avd" />
+            <value value="$USER_HOME$/.android/avd/Resizable_Experimental_API_33.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-04-06T16:31:35.761306Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-04-07T14:52:02.582583Z" />
   </component>
 </project>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,6 +249,7 @@
     <string name="add_to_bookmarks_cd">Add to Bookmarks</string>
     <string name="clear_all_cd">Clear All Messages</string>
     <string name="persona_placeholder_cd">Persona Placeholder</string>
+    <string name="active_chat_cleared">Active chat cleared!</string>
 
     <!--    Dropdown Menu   -->
     <string name="more_options_cd">More Options</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,8 @@
     <string name="bookmarked">Bookmarked</string>
     <string name="no_bookmarks_cd">No Bookmarks</string>
     <string name="no_bookmarks">No Bookmarks yet.</string>
+    <string name="delete_bookmarked_success">Bookmark deleted!</string>
+    <string name="delete_bookmarked_cancelled">Bookmark restored!</string>
 
     <!--    MessageList   -->
     <string name="user">User</string>


### PR DESCRIPTION
Addresses #5 

Shows a snackbar to after deleting Active Chat and Bookmarked Chat, with an Undo action to restore accidental deletions.

